### PR TITLE
feat: usar slug como clase dinámica y mover fondos a CS gradients

### DIFF
--- a/src/components/BackgroundCard.astro
+++ b/src/components/BackgroundCard.astro
@@ -4,7 +4,7 @@ const { name, slug, css } = Astro.props;
 ---
 
 <div class="bg-card">
-  <div class="bg-preview" style={css}></div>
+  <div class={`bg-preview ${slug}`}></div>
   <div class="bg-info">
     <h3 class="bg-name">{name}</h3>
     <button class="copy-btn" data-slug={slug} data-css={css}>
@@ -72,31 +72,31 @@ const { name, slug, css } = Astro.props;
     border-color: transparent;
     transform: scale(1.05);
   }
+
+  
 </style>
 
-
 <script>
-  
-    const btns = document.querySelectorAll('.copy-btn');
+  const btns = document.querySelectorAll(".copy-btn");
 
-    btns.forEach(btn => {
-      btn.addEventListener('click', () => {
-        const css = btn.getAttribute('data-css') as string;
-        showCopyFeedback()
-        const cssText = css;
-        
-        const textToCopy = `body {\n ${cssText} \n}`
-        // const body = document.querySelector('body') as HTMLElement;
-        // body.style.cssText = cssText;
-        navigator.clipboard.writeText(textToCopy)
-      });
+  btns.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const css = btn.getAttribute("data-css") as string;
+      showCopyFeedback();
+      const cssText = css;
+
+      const textToCopy = `body { ${cssText} }`;
+      // const body = document.querySelector('body') as HTMLElement;
+      // body.style.cssText = cssText;
+      navigator.clipboard.writeText(textToCopy);
     });
+  });
 
-    // Mostrar feedback visual cuando se copia
+  // Mostrar feedback visual cuando se copia
   function showCopyFeedback() {
     // Crear elemento de notificación
-    const notification = document.createElement("div")
-    notification.textContent = "✅ ¡Código copiado al portapapeles!"
+    const notification = document.createElement("div");
+    notification.textContent = "✅ ¡Código copiado al portapapeles!";
     notification.style.cssText = `
           position: fixed;
           bottom: 20px;
@@ -110,22 +110,21 @@ const { name, slug, css } = Astro.props;
           box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
           transform: translateX(100%);
           transition: transform 0.3s ease;
-      `
-  
-    document.body.appendChild(notification)
-  
+      `;
+
+    document.body.appendChild(notification);
+
     // Animar entrada
     setTimeout(() => {
-      notification.style.transform = "translateX(0)"
-    }, 100)
-  
+      notification.style.transform = "translateX(0)";
+    }, 100);
+
     // Animar salida y remover
     setTimeout(() => {
-      notification.style.transform = "translateX(100%)"
+      notification.style.transform = "translateX(100%)";
       setTimeout(() => {
-        document.body.removeChild(notification)
-      }, 300)
-    }, 2000)
+        document.body.removeChild(notification);
+      }, 300);
+    }, 2000);
   }
-  
 </script>

--- a/src/data/backgrounds.json
+++ b/src/data/backgrounds.json
@@ -3,7 +3,7 @@
     "slug": "gradiente-suave",
     "name": "Gradiente Suave",
     "category": "Gradientes",
-    "css": " background: linear-gradient(135deg, #667eea, #764ba2);"
+    "css": "background: linear-gradient(135deg, #667eea, #764ba2);"
   },
   {
     "slug": "orb-grid",
@@ -18,93 +18,69 @@
     "css": "background: linear-gradient(135deg, #ff006e, #8338ec, #3a86ff);"
   },
   {
-    "slug": "gradient-2",
-    "name": "Gradiente con Patrón",
-    "category": "Gradientes",
-    "css": "background: linear-gradient(45deg, #8338ec, #3a86ff);\nposition: relative;\n\n/* Agregar este pseudo-elemento para el patrón */\n&::before {\n    content: '';\n    position: absolute;\n    top: 0;\n    left: 0;\n    right: 0;\n    bottom: 0;\n    background: url(\"data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E\");\n}"
-  },
-  {
-    "slug": "geometric-1",
-    "name": "Geométrico 1",
-    "category": "Geométricos",
-    "css": "background: #1a1a2e;\nbackground-image: \n    linear-gradient(45deg, #ff006e 25%, transparent 25%), \n    linear-gradient(-45deg, #ff006e 25%, transparent 25%), \n    linear-gradient(45deg, transparent 75%, #8338ec 75%), \n    linear-gradient(-45deg, transparent 75%, #8338ec 75%);\nbackground-size: 20px 20px;\nbackground-position: 0 0, 0 10px, 10px -10px, -10px 0px;"
-  },
-  {
-    "slug": "mesh-1",
-    "name": "Mesh 1",
-    "category": "Mesh",
-    "css": "background: radial-gradient(circle at 25% 25%, #3a86ff 0%, transparent 50%),\n            radial-gradient(circle at 75% 75%, #06ffa5 0%, transparent 50%),\n            linear-gradient(135deg, #0a0a0f, #1a1a2e);"
-  },
-  {
-    "slug": "radial-1",
-    "name": "Radial 1",
-    "category": "Radiales",
-    "css": "background: radial-gradient(circle at center, #ff006e, #8338ec, #0a0a0f);"
-  },
-  {
     "slug": "noise-1",
     "name": "Ruido 1",
     "category": "Texturas",
-    "css": "background: #0a0a0f;\nbackground-image: \n    radial-gradient(circle at 1px 1px, rgba(255,255,255,0.15) 1px, transparent 0); background-size: 20px 20px;"
+    "css": "background: #0a0a0f;\nbackground-image: \n    radial-gradient(circle at 1px 1px, rgba(255,255,255,0.15) 1px, transparent 0); background-size: 20px 20px; background-attachment: fixed;"
   },
   {
     "slug": "gradiente-amanecer",
     "name": "Gradiente Amanecer",
     "category": "Gradientes",
-    "css": "background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 99%, #fad0c4 100%); "
+    "css": "background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 99%, #fad0c4 100%); background-attachment: fixed;"
   },
   {
     "slug": "gradiente-oceanico",
     "name": "Gradiente Oceánico",
     "category": "Gradientes",
-    "css": "background: linear-gradient(to top, #30cfd0 0%, #330867 100%); "
+    "css": "background: linear-gradient(to top, #30cfd0 0%, #330867 100%); background-attachment: fixed;"
   },
   {
     "slug": "patron-cuadricula",
     "name": "Patrón Cuadrícula",
     "category": "Patrones",
-    "css": "background-color: #1e293b; background-image: linear-gradient(to right, rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.05) 1px, transparent 1px); background-size: 40px 40px; "
+    "css": "background-color: #1e293b; background-image: linear-gradient(to right, rgba(255,255,255,0.05) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.05) 1px, transparent 1px); background-size: 40px 40px; background-attachment: fixed;"
   },
   {
     "slug": "mesh-vibrante",
     "name": "Mesh Vibrante",
     "category": "Mesh",
-    "css": "background: radial-gradient(circle at 20% 20%, #ff6ec4, transparent 50%), radial-gradient(circle at 80% 80%, #7873f5, transparent 50%), linear-gradient(135deg, #0f2027, #203a43, #2c5364); "
+    "css": "background: radial-gradient(circle at 20% 20%, #ff6ec4, transparent 50%), radial-gradient(circle at 80% 80%, #7873f5, transparent 50%), linear-gradient(135deg, #0f2027, #203a43, #2c5364); background-attachment: fixed; "
   },
   {
     "slug": "orb-magenta",
     "name": "Orb Magenta",
     "category": "Orbs",
-    "css": "background: #020617; background-image: linear-gradient(to right, rgba(71,85,105,0.15) 1px, transparent 1px), linear-gradient(to bottom, rgba(71,85,105,0.15) 1px, transparent 1px), radial-gradient(circle at 50% 60%, rgba(236,72,153,0.15) 0%, rgba(168,85,247,0.05) 40%, transparent 70%); background-size: 40px 40px, 40px 40px, 100% 100%; "
+    "css": "background: #020617; background-image: linear-gradient(to right, rgba(71,85,105,0.15) 1px, transparent 1px), linear-gradient(to bottom, rgba(71,85,105,0.15) 1px, transparent 1px), radial-gradient(circle at 50% 60%, rgba(236,72,153,0.15) 0%, rgba(168,85,247,0.05) 40%, transparent 70%); background-size: 40px 40px, 40px 40px, 100% 100%; background-attachment: fixed;"
   },
   {
     "slug": "ruido-sutil",
     "name": "Ruido Sutil",
     "category": "Texturas",
-    "css": "background-color: #111827; background-image: radial-gradient(circle at 1px 1px, rgba(255,255,255,0.05) 1px, transparent 0); background-size: 20px 20px;"
+    "css": "background-color: #111827; background-image: radial-gradient(circle at 1px 1px, rgba(255,255,255,0.05) 1px, transparent 0); background-size: 20px 20px; background-attachment: fixed;"
   },
   {
     "slug": "gradiente-fuego",
     "name": "Gradiente Fuego",
     "category": "Gradientes",
-    "css": "background: linear-gradient(45deg, #f12711, #f5af19); "
-  },
-  {
-    "slug": "diagonales-neon",
-    "name": "Diagonales Neón",
-    "category": "Patrones",
-    "css": "background-color: #0f0f0f; background-image: repeating-linear-gradient(45deg, rgba(0,255,255,0.1) 0 2px, transparent 2px 4px);"
+    "css": "background: linear-gradient(45deg, #f12711, #f5af19); background-attachment: fixed;"
   },
   {
     "slug": "glassmorphism",
     "name": "Glassmorphism",
     "category": "Efectos",
-    "css": "background: linear-gradient(135deg, rgba(255,255,255,0.1), rgba(255,255,255,0)); backdrop-filter: blur(10px);"
+    "css": "background: linear-gradient(135deg, rgba(255,255,255,0.1), rgba(255,255,255,0)); backdrop-filter: blur(10px); background-attachment: fixed;"
   },
   {
     "slug": "radial-aurora",
     "name": "Radial Aurora",
     "category": "Radiales",
-    "css": "background: radial-gradient(circle at center, #00c6ff, #0072ff, #004d99);"
+    "css": "background: radial-gradient(circle at center, #00c6ff, #0072ff, #004d99); background-attachment: fixed;"
+  },
+  {
+    "slug": "crimson-depth",
+    "name": "Crimson Depth",
+    "category": "Radiales",
+    "css": "background: radial-gradient(125% 125% at 50% 100%, #000000 40%, #2b0707 100%); background-attachment: fixed;"
   }
 ]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import "@fontsource/poppins";
 import "@/styles/Globals.css";
+import "@/styles/gradients.css";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 ---
@@ -22,5 +23,3 @@ import Footer from "@/components/Footer.astro";
     <Footer />
   </body>
 </html>
-
-

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,14 +5,8 @@ import BackgroundsGallery from "@/sections/BackgroundsGallery.astro";
 ---
 
 <Layout>
-	
 	<Hero />
 	<BackgroundsGallery />
-
-  
-  
-
-  
 </Layout>
 
 

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -1,7 +1,6 @@
 ---
 
 ---
-
 <!-- Hero Section -->
 <section class="hero">
   <div class="container">
@@ -40,16 +39,6 @@
     position: relative;
   }
 
-  .hero::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-  }
-
   .hero-content {
     position: relative;
     z-index: 1;
@@ -60,6 +49,8 @@
     font-weight: 700;
     margin-bottom: 1rem;
     line-height: 1.2;
+
+    
   }
 
   .gradient-text {
@@ -110,4 +101,12 @@
     color: var(--text-secondary);
     margin-top: 0.25rem;
   }
+  @media (max-width: 320px) {
+    .hero-title {
+      font-size: var(--font-size-2xl);
+    }
+
+  }
+
 </style>
+

--- a/src/styles/gradients.css
+++ b/src/styles/gradients.css
@@ -1,0 +1,106 @@
+.gradiente-suave {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+}
+
+.orb-grid {
+  background: #020617;
+  background-image: linear-gradient(
+      to right,
+      rgba(71, 85, 105, 0.15) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, rgba(71, 85, 105, 0.15) 1px, transparent 1px),
+    radial-gradient(
+      circle at 50% 60%,
+      rgba(236, 72, 153, 0.15) 0%,
+      rgba(168, 85, 247, 0.05) 40%,
+      transparent 70%
+    );
+  background-size: 40px 40px, 40px 40px, 100% 100%;
+}
+.gradient-1 {
+  background: linear-gradient(135deg, #ff006e, #8338ec, #3a86ff);
+}
+.noise-1 {
+  background: #0a0a0f;
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    rgba(255, 255, 255, 0.15) 1px,
+    transparent 0
+  );
+  background-size: 20px 20px;
+  background-attachment: fixed;
+}
+.gradiente-amanecer {
+  background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 99%, #fad0c4 100%);
+  background-attachment: fixed;
+}
+.gradiente-oceanico {
+  background: linear-gradient(to top, #30cfd0 0%, #330867 100%);
+  background-attachment: fixed;
+}
+.patron-cuadricula {
+  background-color: #1e293b;
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 40px 40px;
+  background-attachment: fixed;
+}
+.mesh-vibrante {
+  background: radial-gradient(circle at 20% 20%, #ff6ec4, transparent 50%),
+    radial-gradient(circle at 80% 80%, #7873f5, transparent 50%),
+    linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+  background-attachment: fixed;
+}
+.orb-magenta {
+  background: #020617;
+  background-image: linear-gradient(
+      to right,
+      rgba(71, 85, 105, 0.15) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, rgba(71, 85, 105, 0.15) 1px, transparent 1px),
+    radial-gradient(
+      circle at 50% 60%,
+      rgba(236, 72, 153, 0.15) 0%,
+      rgba(168, 85, 247, 0.05) 40%,
+      transparent 70%
+    );
+  background-size: 40px 40px, 40px 40px, 100% 100%;
+}
+
+.ruido-sutil {
+  background-color: #111827;
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    rgba(255, 255, 255, 0.05) 1px,
+    transparent 0
+  );
+  background-size: 20px 20px;
+  background-attachment: fixed;
+}
+.gradiente-fuego {
+  background: linear-gradient(45deg, #f12711, #f5af19);
+  background-attachment: fixed;
+}
+.glassmorphism {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+  backdrop-filter: blur(10px);
+  background-attachment: fixed;
+}
+.radial-aurora {
+  background: radial-gradient(circle at center, #00c6ff, #0072ff, #004d99);
+  background-attachment: fixed;
+}
+.crimson-depth {
+  background: radial-gradient(
+    125% 125% at 50% 100%,
+    #000000 40%,
+    #2b0707 100%
+  );
+  background-attachment: fixed;
+}


### PR DESCRIPTION
- Ahora cada card utiliza el `slug` como clase dinámica para asignar el fondo.
- Se movieron los estilos de fondo a `gradients.css` para mejor mantenibilidad.
- Eliminado el código inline que inyectaba estilos dinámicos.